### PR TITLE
Add formatter for <iso8601.dateTime> values

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,32 @@
+use iso8601;
+
 pub fn escape_xml(s: &str) -> String {
     s.replace("&", "&amp;").replace("<", "&lt;")
+}
+
+pub fn format_datetime(date_time: &iso8601::DateTime) -> String {
+    let iso8601::Time { hour, minute, second, .. } = date_time.time;
+    
+    match date_time.date {
+        iso8601::Date::YMD { year, month, day } => {
+            format!("{:04}{:02}{:02}T{:02}:{:02}:{:02}",
+                year, month, day,
+                hour, minute, second
+            )
+        }
+        _ => { unimplemented!() }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iso8601;
+
+    #[test]
+    fn formats_datetimes() {
+        let date_time = iso8601::datetime("2016-05-02T06:01:05-0800").unwrap();
+
+        assert_eq!(format_datetime(&date_time), "20160502T06:01:05");
+    }
 }

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,6 @@
 //! Contains the different types of values understood by XML-RPC.
 
-use utils::escape_xml;
+use utils::{escape_xml, format_datetime};
 
 use base64::encode;
 use iso8601::DateTime;
@@ -50,9 +50,8 @@ impl Value {
             Value::Double(d) => {
                 try!(writeln!(fmt, "<double>{}</double>", d));
             }
-            Value::DateTime(_date_time) => {
-                // TODO not easy :(
-                unimplemented!();
+            Value::DateTime(date_time) => {
+                try!(writeln!(fmt, "<dateTime.iso8601>{}</dateTime.iso8601>", format_datetime(&date_time)));
             }
             Value::Base64(ref data) => {
                 try!(writeln!(fmt, "<base64>{}</base64>", encode(data)));


### PR DESCRIPTION
To avoid potential problems with servers that don't expect or can't parse the time zone offset, this formatting code will emit times without time zones.

The XML-RPC specification does not include the time zone offset in ISO8601 dates, nor does it designate a fixed time zone (like UTC). Instead it leaves it up to XML-RPC server implementers to specify time zone details to their clients. I consider this to be a very unfortunate design defect in the protocol.

I think we have no choice but to assume that the caller has already adjusted the time to match the server's expectation.
