### PR TITLE
Use XML version v1.0 in requests. Fixes #12

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ repository = "https://github.com/jonas-schievink/xml-rpc-rs.git"
 keywords = ["xml", "rpc", "remote", "ipc"]
 license = "CC0-1.0"
 name = "xmlrpc"
-version = "0.3.0"
+version = "0.3.1"
 
 [dependencies]
 base64 = "0.2.0"

--- a/src/request.rs
+++ b/src/request.rs
@@ -62,7 +62,7 @@ impl<'a> Request<'a> {
 
     /// Formats this `Request` as XML.
     pub fn write_as_xml<W: Write>(&self, fmt: &mut W) -> io::Result<()> {
-        try!(write!(fmt, r#"<?xml version="1.1" encoding="utf-8"?>"#));
+        try!(write!(fmt, r#"<?xml version="1.0" encoding="utf-8"?>"#));
         try!(write!(fmt, r#"<methodCall>"#));
         try!(write!(fmt, r#"    <methodName>{}</methodName>"#, escape_xml(&self.name)));
         try!(write!(fmt, r#"    <params>"#));


### PR DESCRIPTION
Use the same version as in the original spec as some servers will reject
a newer version and newer XML parsers should also be backwards
compatible.

I guess it's a bit of a trivial patch... :'D