### PR TITLE
Add support for 64-bit integers via <i8></i8>

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -208,6 +208,10 @@ impl<'a, R: Read> Parser<'a, R> {
                         Value::Int(try!(data.parse::<i32>().map_err(|_| {
                             io::Error::new(ErrorKind::Other, format!("invalid value for integer: {}", data))
                         })))
+                    } else if name == &OwnedName::local("i8") {
+                        Value::Int64(try!(data.parse::<i64>().map_err(|_| {
+                            io::Error::new(ErrorKind::Other, format!("invalid value for 64-bit integer: {}", data))
+                        })))
                     } else if name == &OwnedName::local("boolean") {
                         let val = match data.trim() {
                             "0" => false,
@@ -364,6 +368,11 @@ mod tests {
     fn parses_string_value_with_whitespace() {
         assert_eq!(read_value("<value><string>  I'm a string!  </string></value>"),
             Ok(Value::String("  I'm a string!  ".into())));
+    }
+
+    #[test]
+    fn parses_64bit_int() {
+        assert_eq!(read_value("<value><i8>12345</i8></value>"), Ok(Value::Int64(12345)));
     }
 
     #[test]

--- a/src/value.rs
+++ b/src/value.rs
@@ -13,6 +13,11 @@ use std::io::{self, Write};
 pub enum Value {
     /// `<i4>` or `<int>`, 32-bit signed integer.
     Int(i32),
+    /// `<i8>`, 64-bit signed integer.
+    ///
+    /// This is a non-standard feature that may not be supported on all servers
+    /// or clients.
+    Int64(i64),
     /// `<boolean>`, 0 == `false`, 1 == `true`.
     Bool(bool),
     /// `<string>`
@@ -43,6 +48,9 @@ impl Value {
         match *self {
             Value::Int(i) => {
                 try!(writeln!(fmt, "<i4>{}</i4>", i));
+            }
+            Value::Int64(i) => {
+                try!(writeln!(fmt, "<i8>{}</i8>", i));
             }
             Value::Bool(b) => {
                 try!(writeln!(fmt, "<boolean>{}</boolean>", if b { "1" } else { "0" }));


### PR DESCRIPTION
Some applications use `<i8>` for integers. This adds support for it.

Thanks for working on this!