### PR TITLE
Make it possible to change the hyper RequestBuilder

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -104,7 +104,7 @@ impl Display for ParseError {
                 ref expected,
                 ref position,
             } => {
-                write!(fmt, "expected {} at {}", expected, position)
+                write!(fmt, "{} at {}", expected, position)
             }
         }
     }


### PR DESCRIPTION
This is for example necessary to add an Authorization header
to communicate with XML-RPC servers that need a login.

(Note sure of `call_with` is the best possible method name...)