### PR TITLE
Indicate HTTP status != OK as its own error

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -66,6 +66,9 @@ impl Error for RequestError {
 /// Describes possible error that can occur when parsing a `Response`.
 #[derive(Debug, PartialEq)]
 pub enum ParseError {
+    /// The HTTP status code did not indicate success.
+    HttpStatus(String),
+
     /// Error while parsing (malformed?) XML.
     XmlError(XmlError),
 
@@ -98,6 +101,7 @@ impl From<io::Error> for ParseError {
 impl Display for ParseError {
     fn fmt(&self, fmt: &mut Formatter) -> fmt::Result {
         match *self {
+            ParseError::HttpStatus(ref err) => write!(fmt, "HTTP status: {}", err),
             ParseError::XmlError(ref err) => write!(fmt, "malformed XML: {}", err),
             ParseError::InvalidValue(ref desc) => write!(fmt, "invalid value: {}", desc),
             ParseError::UnexpectedXml {
@@ -113,6 +117,7 @@ impl Display for ParseError {
 impl Error for ParseError {
     fn description(&self) -> &str {
         match *self {
+            ParseError::HttpStatus(ref err) => err,
             ParseError::XmlError(ref err) => err.description(),
             ParseError::InvalidValue(ref desc) => desc,
             ParseError::UnexpectedXml { .. } => "unexpected XML content",

--- a/src/request.rs
+++ b/src/request.rs
@@ -1,10 +1,11 @@
 use {Value, Response};
 use parser::parse_response;
-use error::RequestError;
+use error::{ParseError, RequestError};
 use utils::escape_xml;
 
 use hyper::client::{Client, Body};
 use hyper::header::{ContentType, UserAgent};
+use hyper::status::StatusCode;
 
 use std::io::{self, Write};
 
@@ -54,10 +55,14 @@ impl<'a> Request<'a> {
             .send()?;
 
         // FIXME Check that the response headers are correct
-
-        // Read the response and parse it
-        // FIXME `BufRead`?
-        Ok(parse_response(&mut response)?)
+        if response.status != StatusCode::Ok {
+            let st = response.status_raw();
+            Err(ParseError::HttpStatus(format!("{} {}", st.0, st.1)).into())
+        } else {
+            // Read the response and parse it
+            // FIXME `BufRead`?
+            Ok(parse_response(&mut response)?)
+        }
     }
 
     /// Formats this `Request` as XML.


### PR DESCRIPTION
Otherwise, we get "expected <methodResponse>" when there is a
more low-level error such as 401 Unauthorized.