### PR TITLE
expose parser::parse_response

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ mod utils;
 pub use error::{ParseError, RequestError, Fault};
 pub use request::{Request, RequestResult};
 pub use value::Value;
+pub use parser::{ParseResult, parse_response};
 
 /// A response from the server.
 ///


### PR DESCRIPTION
I know it's weird, but the application I'm communicating with, rtorrent, allows one to communicate via XML-RPC wrapped in SCGI over a unix domain socket. It doesn't make much sense to add that functionality to this library since it's pretty obscure, but it's also not currently possible for users to use such a custom transport. Users are able to serialize the request as XML with `Request::write_as_xml`, but they can't then parse the response back because `parser::parse_response` is private.

This change exposes `parser::parse_response`.