### PR TITLE
Introduce Transport trait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ env:
   global:
     - RUSTFLAGS="--deny warnings"
     - RUST_BACKTRACE=1
-script: cargo test
+  matrix:
+    - FEATURES="" # default configuration (with reqwest)
+    - FEATURES="--no-default-features"
+script: cargo test $FEATURES

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+## Unreleased (0.9.0)
+
+* Replace ad-hoc API with a flexible `Transport` trait that can be implemented to change the way the request is sent
+* Make the `reqwest` dependency optional - you can opt out and define your own `Transport` instead
+* Add `Request::call_url`, an easy to use helper that calls a `&str` URL without needing to depend on `reqwest` in downstream crates
+* Stricter checking of server headers
+
+## <= 0.8.0
+
+* The API slowly grew to expose more internals in order to accommodate more use cases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ default = ["reqwest"]
 name = "client"
 required-features = ["reqwest"]
 
+[[example]]
+name = "custom-header"
+required-features = ["reqwest"]
+
 # cargo-release configuration
 [package.metadata.release]
 tag-message = "{{version}}"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,15 @@ version = "0.8.0"
 [dependencies]
 base64 = "0.6.0"
 iso8601 = "0.1.1"
-reqwest = "0.8.0"
 xml-rs = "0.7.0"
+reqwest = { version = "0.8.0", optional = true }
+
+[features]
+default = ["reqwest"]
+
+[[example]]
+name = "client"
+required-features = ["reqwest"]
 
 # cargo-release configuration
 [package.metadata.release]

--- a/examples/client.rs
+++ b/examples/client.rs
@@ -1,19 +1,15 @@
 //! You can use this example by executing `python3 -m xmlrpc.server` and then running
 //! `cargo run --example client`.
 
-extern crate reqwest;
 extern crate xmlrpc;
 
 use xmlrpc::{Request, Value};
-use reqwest::Client;
 
 fn main() {
-    let client = Client::new();
-
     // The Python example server exports Python's `pow` method. Let's call it!
     let pow_request = Request::new("pow").arg(2).arg(8);    // Compute 2**8
 
-    let request_result = pow_request.call(&client, "http://127.0.0.1:8000");
+    let request_result = pow_request.call_url("http://127.0.0.1:8000");
 
     println!("Result: {:?}", request_result);
 

--- a/examples/custom-header.rs
+++ b/examples/custom-header.rs
@@ -1,0 +1,49 @@
+//! This example shows how to transmit a request with a custom HTTP header.
+
+extern crate xmlrpc;
+extern crate reqwest;
+
+use xmlrpc::{Request, Transport};
+use xmlrpc::http::{build_headers, check_response};
+
+use reqwest::{Client, RequestBuilder};
+use reqwest::header::Cookie;
+
+use std::error::Error;
+
+/// Custom transport that adds a cookie header.
+struct MyTransport(RequestBuilder);
+
+impl Transport for MyTransport {
+    type Stream = reqwest::Response;
+
+    fn transmit(mut self, request: &Request) -> Result<Self::Stream, Box<Error>> {
+        let mut body = Vec::new();
+        request.write_as_xml(&mut body).unwrap();
+
+        build_headers(&mut self.0, body.len() as u64);
+
+        // Our custom header will be a `Cookie` header
+        let mut cookie = Cookie::new();
+        cookie.set("SESSION", "123abc");
+        self.0.header(cookie);
+
+        let response = self.0
+            .body(body)
+            .send()?
+            .error_for_status()?;
+
+        check_response(&response)?;
+
+        Ok(response)
+    }
+}
+
+fn main() {
+    let request = Request::new("pow").arg(2).arg(8);
+
+    let tp = MyTransport(Client::new().post("http://localhost/target"));
+    let result = request.call(tp);
+
+    println!("Result: {:?}", result);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,6 @@
 
 extern crate base64;
 extern crate iso8601;
-extern crate reqwest;
 extern crate xml;
 
 mod error;
@@ -17,11 +16,12 @@ mod parser;
 mod request;
 mod value;
 mod utils;
+mod transport;
 
-pub use error::{ParseError, RequestError, Fault};
+pub use error::{RequestError, Fault};
 pub use request::{Request, RequestResult};
 pub use value::Value;
-pub use parser::{ParseResult, parse_response};
+pub use transport::Transport;
 
 /// A response from the server.
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,9 @@ pub use request::{Request, RequestResult};
 pub use value::Value;
 pub use transport::Transport;
 
+#[cfg(feature = "reqwest")]
+pub use transport::http;
+
 /// A response from the server.
 ///
 /// XML-RPC specifies that a call should either return a single `Value`, or a `<fault>`.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -68,6 +68,9 @@ pub mod http {
     /// Content-Length: $body_len
     /// ```
     pub fn build_headers(builder: &mut RequestBuilder, body_len: u64) {
+        // Set all required request headers
+        // NB: The `Host` header is also required, but reqwest adds it automatically, since
+        // HTTP/1.1 requires it.
         builder
             .header(UserAgent::new("Rust xmlrpc"))
             .header(ContentType("text/xml; charset=utf-8".parse().unwrap()))
@@ -110,9 +113,6 @@ pub mod http {
             // and not doing anything else that could return an `Err` in `write_as_xml()`.
             request.write_as_xml(&mut body).unwrap();
 
-            // Set all required request headers
-            // NB: The `Host` header is also required, but reqwest adds it automatically, since
-            // HTTP/1.1 requires it.
             build_headers(&mut self, body.len() as u64);
 
             let response = self

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -53,7 +53,7 @@ pub mod http {
     extern crate reqwest;
 
     use {Request, Transport};
-    use self::reqwest::{Client, RequestBuilder, Url, mime};
+    use self::reqwest::{RequestBuilder, mime};
     use self::reqwest::header::{ContentType, ContentLength, UserAgent};
 
     use std::error::Error;
@@ -125,22 +125,4 @@ pub mod http {
             Ok(response)
         }
     }
-
-    /// Convenience implementation for `Url`. Creates a `Client` and performs a `POST` request to
-    /// the URL.
-    // (this isn't actually that convenient - to parse a URL to have to deal with another layer of
-    // errors)
-    impl Transport for Url {
-        type Stream = reqwest::Response;
-
-        fn transmit(self, request: &Request) -> Result<Self::Stream, Box<Error>> {
-            Client::new().post(self).transmit(request)
-        }
-    }
 }
-
-// TODO: integration test - can you usefully implement this trait from outside?
-// Also test reported use cases:
-// - Cookie support (missing in reqwest!),
-// - Custom useragent
-// - "XML-RPC wrapped in SCGI over a unix domain socket"

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -1,0 +1,108 @@
+use Request;
+
+use std::io::Read;
+use std::error::Error;
+
+/// Request and response transport abstraction.
+///
+/// The `Transport` trait provides a way to send a `Request` to a server and to receive the
+/// corresponding response. A `Transport` implementor is passed to `Request::call` in order to use
+/// it to perform that request.
+///
+/// The most commonly used transport is simple HTTP: If the `reqwest` feature is enabled (it is by
+/// default), the reqwest `Client` will implement this trait and send the XML-RPC `Request` via
+/// HTTP.
+///
+/// You can implement this trait for your own types if you want to customize how requests are sent.
+/// You can modify HTTP headers or wrap requests in a completely different protocol.
+pub trait Transport {
+    // FIXME replace with `impl Trait` when stable
+    /// The response stream returned by `transmit`.
+    type Stream: Read;
+
+    /// Transmits an XML-RPC request and returns the server's response.
+    ///
+    /// The response is returned as a `Self::Stream` - some type implementing the `Read` trait. The
+    /// library will read all of the data and parse it as a response. It must be UTF-8 encoded XML,
+    /// otherwise the call will fail.
+    ///
+    /// If a transport error occurs, this should return it as a boxed error - the library will
+    /// interpret it as a transport error and return an appropriate `RequestError`.
+    fn transmit(self, request: &Request) -> Result<Self::Stream, Box<Error>>;
+}
+
+/// Contains `Transport` implementations for types of the `reqwest` crate.
+#[cfg(feature = "reqwest")]
+mod reqwest {
+    extern crate reqwest;
+
+    use {Request, Transport};
+    use self::reqwest::{Client, RequestBuilder, Url, mime};
+    use self::reqwest::header::{ContentType, ContentLength, UserAgent};
+
+    use std::error::Error;
+
+    /// Use a `RequestBuilder` as the transport.
+    ///
+    /// The request will be sent as specified in the XML-RPC specification: A default `User-Agent`
+    /// will be set, along with the correct `Content-Type` and `Content-Length`.
+    impl Transport for RequestBuilder {
+        type Stream = reqwest::Response;
+
+        fn transmit(mut self, request: &Request) -> Result<Self::Stream, Box<Error>> {
+            // First, build the body XML
+            let mut body = Vec::new();
+            // This unwrap never panics as we are using `Vec<u8>` as a `Write` implementor,
+            // and not doing anything else that could return an `Err` in `write_as_xml()`.
+            request.write_as_xml(&mut body).unwrap();
+
+            // Set all required request headers
+            // NB: The `Host` header is also required, but reqwest adds it automatically, since
+            // HTTP/1.1 requires it.
+            let builder = self
+                .header(UserAgent::new("Rust xmlrpc"))
+                .header(ContentType("text/xml; charset=utf-8".parse().unwrap()))
+                .header(ContentLength(body.len() as u64));
+
+            let response = builder
+                .body(body)
+                .send()?
+                .error_for_status()?;
+
+            // Check response headers
+            // "The Content-Type is text/xml. Content-Length must be present and correct."
+            if let Some(content) = response.headers().get::<ContentType>() {
+                // (we ignore this if the header is missing completely)
+                match (content.type_(), content.subtype()) {
+                    (mime::TEXT, mime::XML) => {},
+                    (ty, sub) => return Err(
+                        format!("expected Content-Type 'text/xml', got '{}/{}'", ty, sub).into()
+                    ),
+                }
+            }
+
+            response.headers().get::<ContentLength>()
+                .ok_or_else(|| format!("expected Content-Length header, but none was found"))?;
+
+            Ok(response)
+        }
+    }
+
+    /// Convenience implementation for `Url`. Creates a `Client` and performs a `POST` request to
+    /// the URL.
+    // (this isn't actually that convenient - to parse a URL to have to deal with another layer of
+    // errors)
+    impl Transport for Url {
+        type Stream = reqwest::Response;
+
+        fn transmit(self, request: &Request) -> Result<Self::Stream, Box<Error>> {
+            Client::new().post(self).transmit(request)
+        }
+    }
+}
+
+// TODO: integration test - can you usefully implement this trait from outside?
+// Also test reported use cases:
+// - Cookie support (missing in reqwest!),
+// - Custom useragent
+// - "XML-RPC wrapped in SCGI over a unix domain socket"

--- a/src/value.rs
+++ b/src/value.rs
@@ -133,6 +133,8 @@ impl From<DateTime> for Value {
     }
 }
 
+// FIXME This impl isn't obvious - theoretically you can use <string> to transfer binary data!
+// (also see https://github.com/jonas-schievink/xml-rpc-rs/issues/17)
 impl From<Vec<u8>> for Value {
     fn from(other: Vec<u8>) -> Self {
         Value::Base64(other)


### PR DESCRIPTION
These are my plans for the future of this crate. All ad-hoc additions to the API (many of which exposed more internals than I'm comfortable with) should be replaced by this - I don't think any use-case I've seen cannot be realized with a `Transport` impl.

As a nice side effect, this makes `reqwest` optional, which is by far our heaviest dependency. Users who don't need the HTTP transport can opt out of it.

After this lands, I will hide most error details and unify all errors so performing a request will just return a `Result<Value, RequestError>` instead of a nested `Result` - any `<fault>` returned by the server will end up as a `RequestError`, which better meets the requirements of most applications.