### PR TITLE
Add From<i64> implementation for Value.

### DIFF
--- a/src/value.rs
+++ b/src/value.rs
@@ -103,6 +103,12 @@ impl From<i32> for Value {
     }
 }
 
+impl From<i64> for Value {
+    fn from(other: i64) -> Self {
+        Value::Int64(other)
+    }
+}
+
 impl From<bool> for Value {
     fn from(other: bool) -> Self {
         Value::Bool(other)


### PR DESCRIPTION
There's an implementation of From<i32>, so it makes sense to have one for i64, especially since Int64 is one of the variants of Value.