### PR TITLE
Update reqwest to be compatible to openssl 1.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ version = "0.12.0"
 base64 = "0.9.0"
 iso8601 = "0.2.0"
 xml-rs = "0.7.0"
-reqwest = { version = "0.9.0", optional = true }
+reqwest = { version = "0.9", optional = true }
 mime = { version = "0.3", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
The specified `reqwest` version fails to build with the recent openssl version (tested on Arch Linux).
Allow using newer 0.9 versions with this commit.

`cargo test` does not report any errors.