### PR TITLE
Update reqwest requirement from 0.9.0 to 0.10.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.36.0
+  - 1.37.0
   - stable
   - nightly
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: rust
 rust:
-  - 1.37.0
+  - 1.39.0
   - stable
   - nightly
 sudo: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 # public
 iso8601 = "0.3.0"
-reqwest = { version = "0.9.0", optional = true }
+reqwest = { version = "0.10.1", features = [ "blocking" ], optional = true }
 # private
 mime = { version = "0.3", optional = true }
 base64 = "0.11.0"

--- a/examples/custom-header.rs
+++ b/examples/custom-header.rs
@@ -7,7 +7,7 @@ use xmlrpc::http::{build_headers, check_response};
 use xmlrpc::{Request, Transport};
 
 use reqwest::header::COOKIE;
-use reqwest::{Client, RequestBuilder};
+use reqwest::blocking::{Client, RequestBuilder, Response};
 
 use std::error::Error;
 
@@ -15,7 +15,7 @@ use std::error::Error;
 struct MyTransport(RequestBuilder);
 
 impl Transport for MyTransport {
-    type Stream = reqwest::Response;
+    type Stream = Response;
 
     fn transmit(self, request: &Request) -> Result<Self::Stream, Box<dyn Error + Send + Sync>> {
         let mut body = Vec::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -42,10 +42,6 @@ impl Display for Error {
 }
 
 impl error::Error for Error {
-    fn description(&self) -> &str {
-        self.0.description()
-    }
-
     fn source(&self) -> Option<&(dyn error::Error + 'static)> {
         self.0.source()
     }
@@ -88,14 +84,6 @@ impl Display for RequestErrorKind {
 }
 
 impl error::Error for RequestErrorKind {
-    fn description(&self) -> &str {
-        match *self {
-            RequestErrorKind::ParseError(_) => "parse error",
-            RequestErrorKind::TransportError(_) => "transport error",
-            RequestErrorKind::Fault(_) => "server returned a fault",
-        }
-    }
-
     fn cause(&self) -> Option<&dyn error::Error> {
         match *self {
             RequestErrorKind::ParseError(ref err) => Some(err),
@@ -181,13 +169,6 @@ impl Display for ParseError {
 }
 
 impl error::Error for ParseError {
-    fn description(&self) -> &str {
-        match *self {
-            ParseError::XmlError(ref err) => err.description(),
-            ParseError::InvalidValue { .. } => "invalid value for type",
-            ParseError::UnexpectedXml { .. } => "unexpected XML content",
-        }
-    }
 }
 
 /// A `<fault>` response, indicating that a request failed.
@@ -254,9 +235,6 @@ impl Display for Fault {
 }
 
 impl error::Error for Fault {
-    fn description(&self) -> &str {
-        &self.fault_string
-    }
 }
 
 #[cfg(test)]

--- a/src/request.rs
+++ b/src/request.rs
@@ -111,7 +111,7 @@ impl<'a> Request<'a> {
         // While we could implement `Transport` for `T: IntoUrl`, such an impl might not be
         // completely obvious (as it applies to `&str`), so I've added this method instead.
         // Might want to reconsider if someone has an objection.
-        self.call(reqwest::Client::new().post(url))
+        self.call(reqwest::blocking::Client::new().post(url))
     }
 
     /// Formats this `Request` as a UTF-8 encoded XML document.

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -67,7 +67,7 @@ pub mod http {
 
     use self::mime::Mime;
     use self::reqwest::header::{CONTENT_LENGTH, CONTENT_TYPE, USER_AGENT};
-    use self::reqwest::RequestBuilder;
+    use self::reqwest::blocking::RequestBuilder;
     use {Request, Transport};
 
     use std::error::Error;
@@ -95,7 +95,7 @@ pub mod http {
     /// Checks that a reqwest `Response` has a status code indicating success and verifies certain
     /// headers.
     pub fn check_response(
-        response: &reqwest::Response,
+        response: &reqwest::blocking::Response,
     ) -> Result<(), Box<dyn Error + Send + Sync>> {
         // This is essentially an open-coded version of `Response::error_for_status` that does not
         // consume the response.
@@ -133,7 +133,7 @@ pub mod http {
     /// The request will be sent as specified in the XML-RPC specification: A default `User-Agent`
     /// will be set, along with the correct `Content-Type` and `Content-Length`.
     impl Transport for RequestBuilder {
-        type Stream = reqwest::Response;
+        type Stream = reqwest::blocking::Response;
 
         fn transmit(
             self,


### PR DESCRIPTION
I'm using your fantastic library in one my small tools and whilst updating and reviewing my dependencies it turned out to be the only dependency that's still pulling in tokio 0.1. And update to reqwest would alleviate that.

The other pull request triggered by dependabot fails because the blocking API has been moved to a separate module and requires a feature flag to be enabled. Apart from those changes everything appears to be working.