### PR TITLE
Allow disabling TLS support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ### Breaking Changes
 
 * Updated `iso8601` dependency to 0.3.0
+* Added a new default feature named `tls` that depends on the (default) tls support in [reqwest].
+
+[reqwest]: https://github.com/seanmonstar/reqwest
 
 ## 0.13.1 - 2019-02-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Breaking Changes
 
 * Updated `iso8601` dependency to 0.3.0
-* Added a new default feature named `tls` that depends on the (default) tls support in [reqwest].
+* Added a new default feature `tls` that can be disabled to turn off [reqwest]'s TLS support.
 
 [reqwest]: https://github.com/seanmonstar/reqwest
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 # public
 iso8601 = "0.3.0"
-reqwest = { version = "0.10.1", features = [ "blocking" ], optional = true }
+reqwest = { version = "0.10.1", features = [ "blocking" ], default-features = false, optional = true }
 # private
 mime = { version = "0.3", optional = true }
 base64 = "0.11.0"
@@ -28,7 +28,8 @@ version-sync = "0.8"
 
 [features]
 http = ["reqwest", "mime"]
-default = ["http"]
+tls = ["reqwest/default-tls"]
+default = ["http", "tls"]
 
 [[example]]
 name = "client"


### PR DESCRIPTION
This allows one to disable TLS support which is enabled by default in reqwest.

To disable TLS support one would use:
```
xmlrpc = { version="*", features = ["http"], default-features=false }
```

This approach is recommended in https://stackoverflow.com/questions/48677352/turn-off-default-features-in-dependency-of-dependency -- please let me know what you think about this change.
