### PR TITLE
Altered insertion of newlines and spaces in data as its written to the transport

### DIFF
--- a/src/request.rs
+++ b/src/request.rs
@@ -121,20 +121,20 @@ impl<'a> Request<'a> {
     /// Any errors reported by the writer will be propagated to the caller. If the writer never
     /// returns an error, neither will this method.
     pub fn write_as_xml<W: Write>(&self, fmt: &mut W) -> io::Result<()> {
-        write!(fmt, r#"<?xml version="1.0" encoding="utf-8"?>"#)?;
-        write!(fmt, r#"<methodCall>"#)?;
-        write!(
+        writeln!(fmt, r#"<?xml version="1.0" encoding="utf-8"?>"#)?;
+        writeln!(fmt, r#"<methodCall>"#)?;
+        writeln!(
             fmt,
-            r#"    <methodName>{}</methodName>"#,
+            r#"<methodName>{}</methodName>"#,
             escape_xml(&self.name)
         )?;
-        write!(fmt, r#"    <params>"#)?;
+        writeln!(fmt, r#"<params>"#)?;
         for value in &self.args {
-            write!(fmt, r#"        <param>"#)?;
+            writeln!(fmt, r#"<param>"#)?;
             value.write_as_xml(fmt)?;
-            write!(fmt, r#"        </param>"#)?;
+            writeln!(fmt, r#"</param>"#)?;
         }
-        write!(fmt, r#"    </params>"#)?;
+        writeln!(fmt, r#"</params>"#)?;
         write!(fmt, r#"</methodCall>"#)?;
         Ok(())
     }

--- a/src/value.rs
+++ b/src/value.rs
@@ -108,33 +108,33 @@ impl Value {
     ///
     /// Any error reported by the writer will be propagated to the caller.
     pub fn write_as_xml<W: Write>(&self, fmt: &mut W) -> io::Result<()> {
-        writeln!(fmt, "<value>")?;
+        write!(fmt, "<value>")?;
 
         match *self {
             Value::Int(i) => {
-                writeln!(fmt, "<i4>{}</i4>", i)?;
+                write!(fmt, "<i4>{}</i4>", i)?;
             }
             Value::Int64(i) => {
-                writeln!(fmt, "<i8>{}</i8>", i)?;
+                write!(fmt, "<i8>{}</i8>", i)?;
             }
             Value::Bool(b) => {
-                writeln!(fmt, "<boolean>{}</boolean>", if b { "1" } else { "0" })?;
+                write!(fmt, "<boolean>{}</boolean>", if b { "1" } else { "0" })?;
             }
             Value::String(ref s) => {
-                writeln!(fmt, "<string>{}</string>", escape_xml(s))?;
+                write!(fmt, "<string>{}</string>", escape_xml(s))?;
             }
             Value::Double(d) => {
-                writeln!(fmt, "<double>{}</double>", d)?;
+                write!(fmt, "<double>{}</double>", d)?;
             }
             Value::DateTime(date_time) => {
-                writeln!(
+                write!(
                     fmt,
                     "<dateTime.iso8601>{}</dateTime.iso8601>",
                     format_datetime(&date_time)
                 )?;
             }
             Value::Base64(ref data) => {
-                writeln!(fmt, "<base64>{}</base64>", encode(data))?;
+                write!(fmt, "<base64>{}</base64>", encode(data))?;
             }
             Value::Struct(ref map) => {
                 writeln!(fmt, "<struct>")?;
@@ -144,19 +144,19 @@ impl Value {
                     value.write_as_xml(fmt)?;
                     writeln!(fmt, "</member>")?;
                 }
-                writeln!(fmt, "</struct>")?;
+                write!(fmt, "</struct>")?;
             }
             Value::Array(ref array) => {
-                writeln!(fmt, "<array>")?;
+                write!(fmt, "<array>")?;
                 writeln!(fmt, "<data>")?;
                 for value in array {
                     value.write_as_xml(fmt)?;
                 }
-                writeln!(fmt, "</data>")?;
-                writeln!(fmt, "</array>")?;
+                write!(fmt, "</data>")?;
+                write!(fmt, "</array>")?;
             }
             Value::Nil => {
-                writeln!(fmt, "<nil/>")?;
+                write!(fmt, "<nil/>")?;
             }
         }
 
@@ -393,7 +393,7 @@ mod tests {
             .unwrap();
         assert_eq!(
             str::from_utf8(&output).unwrap(),
-            "<value>\n<string>&lt;xml>&amp;nbsp;string</string>\n</value>\n"
+            "<value><string>&lt;xml>&amp;nbsp;string</string></value>\n"
         );
     }
 
@@ -404,7 +404,7 @@ mod tests {
         map.insert("x&<x".to_string(), Value::from(true));
 
         Value::Struct(map).write_as_xml(&mut output).unwrap();
-        assert_eq!(str::from_utf8(&output).unwrap(), "<value>\n<struct>\n<member>\n<name>x&amp;&lt;x</name>\n<value>\n<boolean>1</boolean>\n</value>\n</member>\n</struct>\n</value>\n");
+        assert_eq!(str::from_utf8(&output).unwrap(), "<value><struct>\n<member>\n<name>x&amp;&lt;x</name>\n<value><boolean>1</boolean></value>\n</member>\n</struct></value>\n");
     }
 
     #[test]


### PR DESCRIPTION
I've been experimenting with this crate and happened to be checking the request that was sent over the network with Wireshark and the resulting request seemed a little strangely formatted. I made changes to remove added whitespace in the `Request::write_as_xml` method and changed when newlines are added in `Value::write_as_xml`. I was working with a relatively simple request structure, but here's the before-and-after:

```
<?xml version="1.0" encoding="utf-8"?><methodCall>    <methodName>getSystemState</methodName>    <params>        <param><value>
<string>/rostopic</string>
</value>
        </param>    </params></methodCall>
```

```
<?xml version="1.0" encoding="utf-8"?>
<methodCall>
<methodName>getSystemState</methodName>
<params>
<param>
<value><string>/rostopic</string></value>
</param>
</params>
</methodCall>
```

The protocol is pretty heavy, but I figure no sense in adding significant amounts of whitespace unless you want to pull it out and look at it, in which case you can use a tool to add the spaces.