### PR TITLE
Don't use reqwest::blocking resolves #60

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,10 @@
 ## Unreleased
 
 * Updated to Rust 2021 Syntax
-* Updated `reqwest`to 0.11.1
+* Updated `reqwest`to 0.11.10
+* Added `tokio` dependency for async runtime (feature rt-multi-thread)
 
-- Added `async` feature
-- Refactored to not use `reqwest::blocking`
+- Refactored to not use `reqwest::blocking`, all interfaces stay stable
 
 ## 0.15.1 - 2021-11-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Unreleased
 
-No changes.
+* Updated to Rust 2021 Syntax
+* Updated `reqwest`to 0.11.1
+
+- Added `async` feature
+- Refactored to not use `reqwest::blocking`
 
 ## 0.15.1 - 2021-11-02
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,13 +49,13 @@ xml-rs = "0.8.0"
 futures = "0.3.21"
 
 [dependencies.reqwest]
-version = "0.11.*"
+version = "0.11.10"
 default-features = false
 optional = true
 
 [dependencies.tokio]
-version = "1.17.*"
-features = ["full"]
+version = "1.17.0"
+features = ["rt-multi-thread"]
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 license = "CC0-1.0"
 name = "xmlrpc"
 version = "0.15.1"
+edition = "2021"
 
 # cargo-release configuration
 [package.metadata.release]
@@ -41,11 +42,20 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 # public
 iso8601 = "0.4.0"
-reqwest = { version = "0.11.0", features = [ "blocking" ], default-features = false, optional = true }
 # private
 mime = { version = "0.3", optional = true }
 base64 = "0.13.0"
 xml-rs = "0.8.0"
+futures = "0.3.21"
+
+[dependencies.reqwest]
+version = "0.11.*"
+default-features = false
+optional = true
+
+[dependencies.tokio]
+version = "1.17.*"
+features = ["full"]
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,11 +42,20 @@ maintenance = { status = "actively-developed" }
 [dependencies]
 # public
 iso8601 = "0.5.0"
-reqwest = { version = "0.11.0", features = [ "blocking" ], default-features = false, optional = true }
 # private
 mime = { version = "0.3", optional = true }
 base64 = "0.13.0"
 xml-rs = "0.8.4"
+futures = "0.3.21"
+
+[dependencies.reqwest]
+version = "0.11.10"
+default-features = false
+optional = true
+
+[dependencies.tokio]
+version = "1.17.0"
+features = ["rt-multi-thread"]
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,6 @@ version-sync = "0.9"
 
 [features]
 http = ["reqwest", "mime"]
-async = ["reqwest", "mime"]
 tls = ["reqwest/default-tls"]
 default = ["http", "tls"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["network-programming", "encoding"]
 readme = "README.md"
 license = "CC0-1.0"
 name = "xmlrpc"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 
 # cargo-release configuration
@@ -62,6 +62,7 @@ version-sync = "0.9"
 
 [features]
 http = ["reqwest", "mime"]
+async = ["reqwest", "mime"]
 tls = ["reqwest/default-tls"]
 default = ["http", "tls"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,21 +41,12 @@ maintenance = { status = "actively-developed" }
 
 [dependencies]
 # public
-iso8601 = "0.4.0"
+iso8601 = "0.5.0"
+reqwest = { version = "0.11.0", features = [ "blocking" ], default-features = false, optional = true }
 # private
 mime = { version = "0.3", optional = true }
 base64 = "0.13.0"
-xml-rs = "0.8.0"
-futures = "0.3.21"
-
-[dependencies.reqwest]
-version = "0.11.10"
-default-features = false
-optional = true
-
-[dependencies.tokio]
-version = "1.17.0"
-features = ["rt-multi-thread"]
+xml-rs = "0.8.4"
 
 [dev-dependencies]
 version-sync = "0.9"

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Start by adding an entry to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-xmlrpc = "0.15.1"
+xmlrpc = "0.16.0"
 ```
 
 Then import the crate into your Rust code:

--- a/examples/custom-header.rs
+++ b/examples/custom-header.rs
@@ -11,14 +11,15 @@ use reqwest::{Client, RequestBuilder};
 use reqwest::header::COOKIE;
 
 use std::error::Error;
+use std::io::Cursor;
 
 /// Custom transport that adds a cookie header.
 struct MyTransport(RequestBuilder);
 
 impl Transport for MyTransport {
-    type Stream = &'static[u8];
+    type Stream = Cursor<String>;
 
-    fn transmit(self, request: &Request) -> Result<String, Box<dyn Error + Send + Sync>> {
+    fn transmit(self, request: &Request) -> Result<Self::Stream, Box<dyn Error + Send + Sync>> {
         let mut body = Vec::new();
         request
             .write_as_xml(&mut body)
@@ -34,7 +35,7 @@ impl Transport for MyTransport {
         check_response(&resp)?;
 
         let rs = async move {resp.text().await.unwrap()};
-        let rv = block_on(rs);
+        let rv = Cursor::new(block_on(rs));
 
         Ok(rv)
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,6 +1,6 @@
 //! Defines error types used by this library.
 
-use Value;
+use crate::value::Value;
 
 use xml::common::TextPosition;
 use xml::reader::Error as XmlError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! [XML-RPC specification]: http://xmlrpc.scripting.com/spec.html
 
-#![doc(html_root_url = "https://docs.rs/xmlrpc/0.15.1")]
+#![doc(html_root_url = "https://docs.rs/xmlrpc/0.16.0")]
 #![warn(missing_debug_implementations)]
 #![warn(missing_docs)]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@
 
 #![doc(html_root_url = "https://docs.rs/xmlrpc/0.15.1")]
 #![warn(missing_debug_implementations)]
-#![warn(rust_2018_idioms)]
 #![warn(missing_docs)]
 
 extern crate base64;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,7 @@
 //! XML-RPC response parser.
 
-use error::ParseError;
-use {Fault, Value};
+use crate::error::{ParseError, Fault};
+use crate::value::Value;
 
 use base64;
 use iso8601::datetime;
@@ -353,7 +353,7 @@ pub fn parse_response<R: Read>(reader: &mut R) -> ParseResult<Response> {
 mod tests {
     use super::*;
 
-    use error::Fault;
+    use crate::error::Fault;
     use Value;
 
     use std::fmt::Debug;

--- a/src/request.rs
+++ b/src/request.rs
@@ -77,11 +77,11 @@ impl<'a> Request<'a> {
     /// [`call_url`]: #method.call_url
     /// [`Transport`]: trait.Transport.html
     pub fn call<T: Transport>(&self, transport: T) -> Result<Value, Error> {
-        let tr = transport
+        let mut reader = transport
             .transmit(self)
             .map_err(RequestErrorKind::TransportError)?;
 
-        let mut reader = tr.as_bytes();
+        //let mut reader = tr.as_bytes();
 
         let response = parse_response(&mut reader).map_err(RequestErrorKind::ParseError)?;
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -156,12 +156,12 @@ pub mod http {
             };
 
             // execute the async transport in an own thread, to the blocking async execution can be used
-            let rs = std::thread::spawn( || {Runtime::new().unwrap().block_on(async_transport)}).join();
+            let rs = std::thread::spawn( || {Runtime::new().unwrap().block_on(async_transport)}).join().expect("Expected result from async thread");
 
             // error handling of the return value
-            match rs.unwrap() {
+            match rs {
                 Ok(o) => Ok(Cursor::new(o)),
-                Err(error) => Err(Box::new(error)),
+                Err(err) => Err(Box::new(err) as Box<dyn Error + Send + Sync>),
             }
 
             //let rs = std::thread::spawn( || {Runtime::new().unwrap().block_on(async_transport)}).join().unwrap().map_err(|error| Box::new(error) as Box<dyn Error + Send + Sync>);

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -151,7 +151,7 @@ pub mod http {
             // async part needs to go to separate thread because of interference with caller
             let async_transport = async move {
                 let rv = build_headers(self, body.len() as u64).body(body).send().await?;
-                check_response(&rv).unwrap();
+                _ = check_response(&rv);
                 rv.text().await
             };
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -72,7 +72,7 @@ pub mod http {
     use crate::transport::Transport;
     use tokio::runtime::Runtime;
 
-    use std::error::Error;
+    use std::error::{Error, self};
     use std::str::FromStr;
 
     /// Appends all HTTP headers required by the XML-RPC specification to the `RequestBuilder`.
@@ -156,13 +156,16 @@ pub mod http {
             };
 
             // execute the async transport in an own thread, to the blocking async execution can be used
-            let rs = std::thread::spawn( || {Runtime::new().unwrap().block_on(async_transport)}).join().unwrap().map_err(|error| Box::new(error) as Box<dyn Error + Send + Sync>);
+            let rs = std::thread::spawn( || {Runtime::new().unwrap().block_on(async_transport)}).join();
 
             // error handling of the return value
-            match rs {
+            match rs.unwrap() {
                 Ok(o) => Ok(Cursor::new(o)),
-                Err(error) => Err(error as Box<dyn Error + Send + Sync>),
+                Err(error) => Err(Box::new(error)),
             }
+
+            //let rs = std::thread::spawn( || {Runtime::new().unwrap().block_on(async_transport)}).join().unwrap().map_err(|error| Box::new(error) as Box<dyn Error + Send + Sync>);
+
         }
     }
 }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -151,7 +151,7 @@ pub mod http {
             // async part needs to go to separate thread because of interference with caller
             let async_transport = async move {
                 let rv = build_headers(self, body.len() as u64).body(body).send().await?;
-                _ = check_response(&rv);
+                _ = check_response(&rv).expect("No valid response");
                 rv.text().await
             };
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -72,7 +72,7 @@ pub mod http {
     use crate::transport::Transport;
     use tokio::runtime::Runtime;
 
-    use std::error::{Error, self};
+    use std::error::Error;
     use std::str::FromStr;
 
     /// Appends all HTTP headers required by the XML-RPC specification to the `RequestBuilder`.
@@ -151,7 +151,7 @@ pub mod http {
             // async part needs to go to separate thread because of interference with caller
             let async_transport = async move {
                 let rv = build_headers(self, body.len() as u64).body(body).send().await?;
-                _ = check_response(&rv).expect("No valid response");
+                check_response(&rv).expect("No valid response");
                 rv.text().await
             };
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -1,6 +1,6 @@
 //! Contains the different types of values understood by XML-RPC.
 
-use utils::{escape_xml, format_datetime};
+use crate::utils::{escape_xml, format_datetime};
 
 use base64::encode;
 use iso8601::DateTime;

--- a/tests/python.rs
+++ b/tests/python.rs
@@ -96,6 +96,7 @@ fn run_tests() {
     Fault::from_value(&results[2]).expect("expected fault as third result");
 }
 
+
 fn main() {
     let mut reaper = match setup() {
         Ok(reap) => reap,


### PR DESCRIPTION
Hi Jonas

This is a working minimal version without any noticeable regressions for the elimination of reqwest::blocking.
I have refactored the transport implementation to use reqwest and used tokio Runtime (in order to avoid additional dependencies) to execute the blocking thread. As a return value I chose the Cursor<String> which lefts the trait untouched and can be properly handled.
I also updated to the 2021 syntax and upgraded some of the dependencies.

I hope you find all the necessary work done properly (this is my firs PR for a Rust crate). Otherwise let me know if I need to change anything.

Best
P